### PR TITLE
User AD groups, roles and access

### DIFF
--- a/components/user/hooks/useUserImage.js
+++ b/components/user/hooks/useUserImage.js
@@ -1,7 +1,7 @@
 import { useSession } from "next-auth/client";
 import * as React from "react";
 import useSWR from "swr";
-import { fetchWithToken } from "../../../utils/fetcher";
+import { fetchBlobWithToken } from "../../../utils/fetcher";
 
 // The supported sizes of HD photos on Microsoft 365 are as follows:
 // 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648.
@@ -15,7 +15,7 @@ export default function useUserImage(size = "240x240") {
 
   const { data } = useSWR(
     () => [`https://graph.microsoft.com/v1.0/me/photos/${size}/$value`, session.accessToken],
-    fetchWithToken
+    fetchBlobWithToken
   );
 
   React.useEffect(() => {

--- a/components/yearStatistic.js
+++ b/components/yearStatistic.js
@@ -13,7 +13,7 @@ export default function YearStatistic({
   ...other
 }) {
   return isLoading ? (
-    <div>
+    <div className="mb-12">
       <HeadingSkeleton />
       <StatisticGroup>
         <StatisticSkeleton />
@@ -23,7 +23,7 @@ export default function YearStatistic({
       </StatisticGroup>
     </div>
   ) : (
-    <div>
+    <div className="mb-12">
       <Heading>{title}</Heading>
       <StatisticGroup {...other}>
         <Statistic title="Work days" value={yearStatistic.workDays} />

--- a/components/yearlyEarnings.js
+++ b/components/yearlyEarnings.js
@@ -6,7 +6,7 @@ import { UserProfile } from "./user";
 
 export default function YearlyEarnings() {
   return (
-    <div className="flex flex-col lg:flex-row justify-evenly items-center w-full">
+    <div className="flex flex-col lg:flex-row justify-evenly items-center w-full mb-12">
       <div className="order-last md:order-first mb-6">
         <UserProfile />
         <CalculateEarningsInputs />

--- a/pages/access-denied.js
+++ b/pages/access-denied.js
@@ -1,0 +1,63 @@
+import { getSession } from "next-auth/client";
+import * as React from "react";
+import Heading from "../components/heading";
+import Text from "../components/text";
+import { sessionUserIsSpecialist } from "../utils/sessionUtils";
+
+export default function AccessDenied({ session }) {
+  return (
+    <div className="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-white dark:bg-black text-gray-900 dark:text-gray-100 opacity-75 ">
+      <div className="flex flex-col items-center justify-center w-full h-screen max-w-3xl my-0 mx-auto">
+        <div className="mb-6">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-32 w-32"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+        </div>
+        <Heading
+          className="text-center"
+          variant="pageHeading"
+        >{`Hi ${session?.user?.name}`}</Heading>
+        <Text className="text-center">
+          We found an account in your name, but you seem lack access to this app. If this is a
+          mistake and you should have access, then please send an email to{" "}
+          <a className="text-green-500 dark:text-green-400" href="mailto:tommy.barvag@knowit.no">
+            tommy.barvag@knowit.no
+          </a>{" "}
+          requesting access.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context);
+
+  // Session user is specialist and should not see
+  // access denied page. Redirect to index
+  if (sessionUserIsSpecialist(session)) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false
+      }
+    };
+  }
+
+  return {
+    props: {
+      session
+    }
+  };
+}

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -41,14 +41,21 @@ async function mutateUserWithRoles(user, token) {
 
     return {
       ...user,
+      // To determine the admin role the user needs to have access
+      // to the specialist and admin groups. Could revalidate this to
+      // only requiring access to admin group in the future.
       isAdmin: isSpecialist && accessToAdminGroup(groups),
       isSpecialist
     };
   } catch (error) {
     console.error(error);
 
+    // If group lookup somehow crashes then try to use
+    // old values for user roles or default to false
     return {
-      ...user
+      ...user,
+      isAdmin: user?.isAdmin ?? false,
+      isSpecialist: user?.isSpecialist ?? false
     };
   }
 }

--- a/pages/api/user/[id].js
+++ b/pages/api/user/[id].js
@@ -1,5 +1,6 @@
 import { getSession } from "next-auth/client";
 import redisUser from "../../../lib/redisUser";
+import { getSessionUserId, sessionUserIsAdmin } from "../../../utils/sessionUtils";
 
 export default async (req, res) => {
   const session = await getSession({ req });
@@ -9,6 +10,16 @@ export default async (req, res) => {
   }
 
   const { id } = req.query;
+
+  if (id === null || id === undefined) {
+    return res.status(400).end();
+  }
+
+  const sessionUserId = getSessionUserId(session);
+
+  if (!sessionUserIsAdmin(session) && id?.toLowerCase() !== sessionUserId?.toLowerCase()) {
+    return res.status(403).end();
+  }
 
   const user = await redisUser.getById(id);
 

--- a/pages/api/user/index.js
+++ b/pages/api/user/index.js
@@ -1,11 +1,16 @@
 import { getSession } from "next-auth/client";
 import redisUser from "../../../lib/redisUser";
+import { sessionUserIsAdmin } from "../../../utils/sessionUtils";
 
 export default async (req, res) => {
   const session = await getSession({ req });
 
   if (!session) {
     return res.status(401).end();
+  }
+
+  if (!sessionUserIsAdmin(session)) {
+    return res.status(403).end();
   }
 
   if (req.method === "GET") {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,17 @@
-import { getSession } from "next-auth/client";
 import * as React from "react";
 import Heading from "../components/heading";
 import AuthenticatedLayout from "../components/layouts/authenticatedLayout";
 import YearlyEarnings from "../components/yearlyEarnings";
 import YearStatistic from "../components/yearStatistic";
+import { getResultForAuthenticatedPage } from "../utils/pageUtils";
 import { useSalary } from "../utils/salaryProvider";
 
-export default function Home() {
+export default function Home({ session }) {
   const { yearSalaryStatistics, nextYearSalaryStatistics, isLoadingSalary } = useSalary();
 
   return (
     <>
-      <Heading variant="pageHeading">Overview</Heading>
+      <Heading variant="pageHeading" className="mb-24">{`Hi ${session?.user?.name}`}</Heading>
       <YearlyEarnings />
       <YearStatistic
         title={`${yearSalaryStatistics?.year} overview`}
@@ -28,22 +28,7 @@ export default function Home() {
 }
 
 export async function getServerSideProps(context) {
-  const session = await getSession(context);
-
-  if (session) {
-    return {
-      props: {
-        session
-      }
-    };
-  }
-
-  return {
-    redirect: {
-      destination: "/login",
-      permanent: false
-    }
-  };
+  return getResultForAuthenticatedPage(context);
 }
 
 Home.layoutProps = {

--- a/pages/login.js
+++ b/pages/login.js
@@ -17,31 +17,33 @@ export default function Login({ session }) {
   }, [session]);
 
   return isLoading ? (
-    <div className="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-white dark:bg-black text-gray-900 dark:text-gray-100 opacity-75 flex flex-col items-center justify-center">
-      <div className="mb-6">
-        <svg
-          className="animate-spin -ml-1 mr-3 h-16 w-16 text-green-500 text:bg-green-400"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          ></circle>
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          ></path>
-        </svg>
+    <div className="fixed top-0 left-0 right-0 bottom-0 w-full h-screen z-50 overflow-hidden bg-white dark:bg-black text-gray-900 dark:text-gray-100 opacity-75 ">
+      <div className="flex flex-col items-center justify-center w-full h-screen max-w-3xl my-0 mx-auto">
+        <div className="mb-6">
+          <svg
+            className="animate-spin -ml-1 mr-3 h-16 w-16 text-green-500 text:bg-green-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            ></path>
+          </svg>
+        </div>
+        <Heading variant="pageHeading">Logging you in</Heading>
+        <Text>This may take a few seconds, please don&#39;t close this page.</Text>
       </div>
-      <Heading variant="pageHeading">Logging you in</Heading>
-      <Text>This may take a few seconds, please don't close this page.</Text>
     </div>
   ) : (
     <div className="relative bg-white dark:bg-black overflow-hidden h-screen">

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,9 +1,9 @@
-import { getSession } from "next-auth/client";
 import * as React from "react";
 import Heading from "../components/heading";
 import AuthenticatedLayout from "../components/layouts/authenticatedLayout";
 import Text from "../components/text";
 import { UserProfile, useUser } from "../components/user";
+import { getResultForAuthenticatedPage } from "../utils/pageUtils";
 
 export default function Profile() {
   const { user } = useUser();
@@ -18,22 +18,7 @@ export default function Profile() {
 }
 
 export async function getServerSideProps(context) {
-  const session = await getSession(context);
-
-  if (session) {
-    return {
-      props: {
-        session
-      }
-    };
-  }
-
-  return {
-    redirect: {
-      destination: "/login",
-      permanent: false
-    }
-  };
+  return getResultForAuthenticatedPage(context);
 }
 
 Profile.layoutProps = {

--- a/pages/salary-calculator.js
+++ b/pages/salary-calculator.js
@@ -1,4 +1,3 @@
-import { getSession } from "next-auth/client";
 import * as React from "react";
 import Calendar from "../components/calendar";
 import Heading from "../components/heading";
@@ -10,6 +9,7 @@ import YearStatistic from "../components/yearStatistic";
 import DEFAULT_USER_SALARY from "../constants/defaultUserSalary";
 import { getEarningsForMonth, getEarningsForYear } from "../logic/earningsLogic";
 import { useCalendar } from "../utils/calendarProvider";
+import { getResultForAuthenticatedPage } from "../utils/pageUtils";
 
 export default function SalaryCalculator() {
   const { year, nextYear, monthDetail, isLoadingCalendar } = useCalendar();
@@ -99,22 +99,7 @@ export default function SalaryCalculator() {
 }
 
 export async function getServerSideProps(context) {
-  const session = await getSession(context);
-
-  if (session) {
-    return {
-      props: {
-        session
-      }
-    };
-  }
-
-  return {
-    redirect: {
-      destination: "/login",
-      permanent: false
-    }
-  };
+  return getResultForAuthenticatedPage(context);
 }
 
 SalaryCalculator.layoutProps = {

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -13,6 +13,16 @@ export async function fetchWithToken(url, token) {
     }
   });
 
+  return res.json();
+}
+
+export async function fetchBlobWithToken(url, token) {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
   return res.blob();
 }
 

--- a/utils/pageUtils.js
+++ b/utils/pageUtils.js
@@ -1,0 +1,35 @@
+import { getSession } from "next-auth/client";
+import { sessionUserIsSpecialist } from "./sessionUtils";
+
+export const getResultForAuthenticatedPage = async context => {
+  const session = await getSession(context);
+
+  // Session user is specialist and is granted access
+  // to the app
+  if (sessionUserIsSpecialist(session)) {
+    return {
+      props: {
+        session
+      }
+    };
+  }
+
+  // We have a session user but the session user is not
+  // a specialist. Redirect to access denied
+  if (session) {
+    return {
+      redirect: {
+        destination: "/access-denied",
+        permanent: false
+      }
+    };
+  }
+
+  // No session. Redirect to login
+  return {
+    redirect: {
+      destination: "/login",
+      permanent: false
+    }
+  };
+};

--- a/utils/sessionUtils.js
+++ b/utils/sessionUtils.js
@@ -1,0 +1,5 @@
+import { userIsAdmin, userIsSpecialist } from "./userUtils";
+
+export const sessionUserIsAdmin = session => userIsAdmin(session?.user);
+export const sessionUserIsSpecialist = session => userIsSpecialist(session?.user);
+export const getSessionUserId = session => session?.user?.id;

--- a/utils/userUtils.js
+++ b/utils/userUtils.js
@@ -1,6 +1,9 @@
 import DEFAULT_USER_SALARY from "../constants/defaultUserSalary";
 import { getEarningsForMonth, getEarningsForYear } from "../logic/earningsLogic";
 
+export const userIsAdmin = user => user?.isAdmin ?? false;
+export const userIsSpecialist = user => user?.isSpecialist ?? false;
+
 export const getUserSalaryDetails = user => ({
   hourlyRate: user?.hourlyRate ?? DEFAULT_USER_SALARY.hourlyRate,
   commission: user?.commission ?? DEFAULT_USER_SALARY.commission,


### PR DESCRIPTION
Check users AD groups when logging user in and refreshing access token. Tag user with roles admin and specialist if user is placed in correct AD groups. Add access denied page if user is granted a session but lacking access to correct AD groups